### PR TITLE
Fix DIDAvatar import path

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import DIDAvatar from "/home/gafur/Documents/AI avatar creation here/frontend/src/DIDAvatar.js";
+import DIDAvatar from './DIDAvatar';
 
 
 const App = () => {


### PR DESCRIPTION
## Summary
- update the DIDAvatar import in App.js to use a relative path so React can resolve the module during builds

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d7286b3cc883258b6755c01d7fcbe4